### PR TITLE
Cache tox to cut workflow time

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,7 +34,7 @@ jobs:
 
       fail-fast: false
 
-    name: Tox - ${{ matrix.friendly_name }}
+    name: Tox - ${{ matrix.python_version }}  -${{ matrix.friendly_name }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         python_version:
           - "3.8"
+          - "3.9"
         tox_env:
           - style-black
           - style-isort
@@ -42,6 +43,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python_version }}
+
+      - name: Cache tox
+        uses: actions/cache@v2
+        with:
+          path: .tox
+          key: tox-${{ matrix.python_version }}-${{ matrix.tox_env }}-${{ hashFiles('tox.ini') }}
 
       - name: Install tox
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,7 +34,7 @@ jobs:
 
       fail-fast: false
 
-    name: Tox - ${{ matrix.python_version }}  -${{ matrix.friendly_name }}
+    name: Tox - ${{ matrix.python_version }} - ${{ matrix.friendly_name }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -44,6 +44,7 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
+      # caching cuts down time for tox (for example black) from ~40 secs to 4
       - name: Cache tox
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Cache the .tox directory, including dependancies, to cut run time of GitHub actions.
For example, black went from around 1 minute for the whole job to 20 seconds.

Also start running Python 3.9