### PR TITLE
[Birthday] Ensure correct announce time v2

### DIFF
--- a/birthday/birthday.py
+++ b/birthday/birthday.py
@@ -30,7 +30,7 @@ class Birthday(
     Set yours and get a message and role on your birthday!
     """
 
-    __version__ = "1.0.5"
+    __version__ = "1.0.6"
     __author__ = "Vexed#9000"
 
     def __init__(self, bot: Red) -> None:

--- a/birthday/loop.py
+++ b/birthday/loop.py
@@ -79,10 +79,11 @@ class BirthdayLoop(MixinMeta):
 
             birthday_members: dict[discord.Member, datetime.datetime] = {}
 
-            today_dt = datetime.datetime.utcnow().replace(
+            hour_td = datetime.timedelta(seconds=all_settings[guild.id]["time_utc_s"])
+
+            today_dt = (datetime.datetime.utcnow() - hour_td).replace(
                 hour=0, minute=0, second=0, microsecond=0
             )
-            hour_td = datetime.timedelta(seconds=all_settings[guild.id]["time_utc_s"])
 
             start = today_dt + hour_td
             end = start + datetime.timedelta(days=1)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -360,6 +360,14 @@ Birthday
 ========
 
 *********
+``1.0.6``
+*********
+
+2022-02-08
+
+- Ensure announcements are on the correct day when a non-UTC midnight time is used v2
+
+*********
 ``1.0.5``
 *********
 


### PR DESCRIPTION
Missed that in my previous PR
We shoudn't switch day until we are past configured time or else, role won't be given for 23h59 and announcement will be done earlier than the configured time 

(You might want to change the changelog message since i used the one that you did for the previous pr)