### PR TITLE
[CmdLog] Correct some output strings

### DIFF
--- a/cmdlog/cmdlog.py
+++ b/cmdlog/cmdlog.py
@@ -428,7 +428,7 @@ class CmdLog(commands.Cog):
         logs = [f"[{i.time}] {i}" for i in self.log_cache if i.guild and i.guild.id == server_id]
 
         log_str = f"Generated at {now} for server {server_id}.\n" + (
-            "\n".join(logs) or "It looks like I didn't find anything for that user."
+            "\n".join(logs) or "It looks like I didn't find anything for that server."
         )  # happy doing this because of file previews
         fp = StringIO()
         fp.write(log_str)

--- a/cmdlog/cmdlog.py
+++ b/cmdlog/cmdlog.py
@@ -440,7 +440,7 @@ class CmdLog(commands.Cog):
         if size > max_size:
             await ctx.send(
                 "Hmm, it looks like you've got some seriously long logs! They're over "
-                "the file size limit. Reset with `[p]reload cmdlog` or choose a different user."
+                "the file size limit. Reset with `[p]reload cmdlog` or choose a different server."
             )
             return
         fp.seek(0)
@@ -486,7 +486,7 @@ class CmdLog(commands.Cog):
         if size > max_size:
             await ctx.send(
                 "Hmm, it looks like you've got some seriously long logs! They're over "
-                "the file size limit. Reset with `[p]reload cmdlog` or choose a different user."
+                "the file size limit. Reset with `[p]reload cmdlog` or choose a different command."
             )
             return
         fp.seek(0)


### PR DESCRIPTION
fixed output when using `[p]cmdlog server`
A fix for #84 