### PR TITLE
New username changes

### DIFF
--- a/cmdlog/objects.py
+++ b/cmdlog/objects.py
@@ -153,7 +153,7 @@ class LoggedAppCom(Log):
         app_type: Literal[1, 2, 3],
         target: discord.PartialMessage | discord.User | None,
     ):
-        self.author = BasicDiscordObject(author.id, author.name)
+        self.author = BasicDiscordObject(author.id, str(author))
         self.command = com_name
         self.channel = (
             BasicDiscordObject(channel.id, channel.name)

--- a/cmdlog/objects.py
+++ b/cmdlog/objects.py
@@ -174,11 +174,11 @@ class LoggedAppCom(Log):
         if self.app_type == 1:  # slash com
             if not self.guild or not self.channel:
                 return (
-                    f"Slash command [{self.command}] ran by {self.author.id} [{self.author.name}]"
+                    f"Slash command [{self.command}] ran by {self.author.id} [{str(self.author)}]"
                     " in our DMs."
                 )
             return (
-                f"Slash command [{self.command}] ran by {self.author.id} [{self.author.name}] "
+                f"Slash command [{self.command}] ran by {self.author.id} [{str(self.author)}] "
                 f"in channel {self.channel.id} [{self.channel.name}] "
                 f"in guild {self.guild.id} [{self.guild.name}]"
             )
@@ -191,13 +191,13 @@ class LoggedAppCom(Log):
                 )
             if not self.guild or not self.channel:
                 return (
-                    f"User command [{self.command}] ran by {self.author.id} [{self.author.name}] "
+                    f"User command [{self.command}] ran by {self.author.id} [{str(self.author)}] "
                     f"targeting user {self.target.name} [{self.target.id}]"
                     "in our DMs."
                 )
 
             return (
-                f"User command [{self.command}] ran by {self.author.id} [{self.author.name}] "
+                f"User command [{self.command}] ran by {self.author.id} [{str(self.author)}] "
                 f"targeting user {self.target.name} [{self.target.id}]"
                 f"in channel {self.channel.id} [{self.channel.name}] "
                 f"in guild {self.guild.id} [{self.guild.name}]"
@@ -209,12 +209,12 @@ class LoggedAppCom(Log):
             if not self.guild or not self.channel:
                 return (
                     f"Message command [{self.command}] ran by"
-                    f" {self.author.id} [{self.author.name}] targeting message {self.target.id}in"
+                    f" {self.author.id} [{str(self.author)}] targeting message {self.target.id}in"
                     " our DMs."
                 )
 
             return (
-                f"Message command [{self.command}] ran by {self.author.id} [{self.author.name}] "
+                f"Message command [{self.command}] ran by {self.author.id} [{str(self.author)}] "
                 f"targeting message {self.target.id}"
                 f"in channel {self.channel.id} [{self.channel.name}] "
                 f"in guild {self.guild.id} [{self.guild.name}]"

--- a/roleplay/roleplay.py
+++ b/roleplay/roleplay.py
@@ -166,7 +166,7 @@ class RolePlay(commands.Cog):
         if data["log_channel"]:
             embed = discord.Embed(title="New role play message", description=message.content)
             embed.set_author(
-                name=f"{message.author.display_name} ({message.author.id})",
+                name=f"{str(message.author)} ({message.author.id})",
                 icon_url=message.author.display_avatar.url,
             )
             embed.add_field(name="Jump link", value=new_msg.jump_url)

--- a/timechannel/timechannel.py
+++ b/timechannel/timechannel.py
@@ -266,7 +266,7 @@ class TimeChannel(commands.Cog, TCLoop, metaclass=CompositeMetaClass):
         if actual is None:
             await ctx.send("It looks like that's not a channel I update to.")
         else:
-            await channel.delete(reason=f"Deleted with `tcset remove` by {ctx.author.name}")
+            await channel.delete(reason=f"Deleted with `tcset remove` by {str(ctx.author)}")
             await ctx.send("Ok, I've deleted that channel and will no longer try to update it.")
 
     @commands.is_owner()


### PR DESCRIPTION
Discord is changing how user names work, internally called pomelo.

Username format goes from name#0000 to @name.

Using `str(author)` ensures that, as discord slowly migrates users, the correct format will always be used by the bot.