### PR TITLE
[Calc] typechecking improvements

### DIFF
--- a/calc/calc.py
+++ b/calc/calc.py
@@ -1,15 +1,14 @@
+import decimal
 import re
-from typing import Optional
+from typing import Any, NoReturn, Optional
 
 import discord
 from expr import EvaluatorError, evaluate
 from redbot.core import Config, commands
 from redbot.core.bot import Red
-import decimal
 
 from .vexutils import format_help, format_info, get_vex_logger
 from .view import CalcView, preprocess_expression
-
 
 log = get_vex_logger(__name__)
 
@@ -36,9 +35,9 @@ class Calc(commands.Cog):
         """Thanks Sinbad."""
         return format_help(self, ctx)
 
-    async def red_delete_data_for_user(self, **kwargs) -> None:
+    async def red_delete_data_for_user(self, **kwargs: Any) -> NoReturn:
         """Nothing to delete"""
-        return
+        raise NotImplementedError
 
     @commands.command(hidden=True)
     async def calcinfo(self, ctx: commands.Context):


### PR DESCRIPTION
fixes this Pylance typechecking error:
````
[{
	"resource": "/c:/Users/Cedric/Desktop/cogs/Vex-Cogs/calc/calc.py",
	"owner": "Pylance",
	"code": {
		"value": "reportIncompatibleMethodOverride",
		"target": {
			"$mid": 1,
			"path": "/microsoft/pylance-release/blob/main/docs/diagnostics/reportIncompatibleMethodOverride.md",
			"scheme": "https",
			"authority": "github.com"
		}
	},
	"severity": 8,
	"message": "Method \"red_delete_data_for_user\" overrides class \"CogMixin\" in an incompatible manner\n  Return type mismatch: base method returns type \"CoroutineType[Any, Any, NoReturn]\", override returns type \"CoroutineType[Any, Any, None]\"\n    \"CoroutineType[Any, Any, None]\" is not assignable to \"CoroutineType[Any, Any, NoReturn]\"\n      Type parameter \"_ReturnT_nd_co@CoroutineType\" is covariant, but \"None\" is not a subtype of \"NoReturn\"\n        Type \"None\" is not assignable to type \"NoReturn\"",
	"source": "Pylance",
	"startLineNumber": 38,
	"startColumn": 15,
	"endLineNumber": 38,
	"endColumn": 39,
	"relatedInformation": [
		{
			"startLineNumber": 886,
			"startColumn": 15,
			"endLineNumber": 886,
			"endColumn": 39,
			"message": "Overridden method",
			"resource": "/c:/Users/Cedric/AppData/Local/Programs/Python/Python311/Lib/site-packages/redbot/core/commands/commands.py"
		}
	],
	"origin": "extHost1"
}]
````
and reformats a bit using Ruff.